### PR TITLE
disable XQuery submissions via the REST interface for non-development environments.

### DIFF
--- a/adjust-conf-files.xsl
+++ b/adjust-conf-files.xsl
@@ -157,6 +157,18 @@
         </xsl:copy>
     </xsl:template>
     
+    <xsl:template match="webapp:init-param[webapp:param-name = ('xquery-submission', 'xupdate-submission') and $env ne 'development']">
+        <!-- Deny XQuery submissions and updates via the REST interface -->
+        <xsl:copy>
+            <xsl:element name="param-name" namespace="http://xmlns.jcp.org/xml/ns/javaee">
+                <xsl:value-of select="webapp:param-name"/>
+            </xsl:element>
+            <xsl:element name="param-value" namespace="http://xmlns.jcp.org/xml/ns/javaee">
+                <xsl:text>disabled</xsl:text>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
+    
     <!-- 
         +++++++++++++++++++++++++++++++++++++++++
         $exist.home$/log4j2.xml


### PR DESCRIPTION
The eXistdb REST interface allows for arbitrary XQuery (and XSLT called from XQuery) execution which is a severe security issue for public facing production systems. Several years ago (in https://github.com/eXist-db/exist/commit/ee7a13922937e853701671bece8c27ce8a31be17) configuration options have been added to disable this functionality.

The current PR updates the script which sets these configuration options in our Docker image. It is now possible to disable XQuery and XUpdate execution via submission through the env variable `EXIST_ENV=production`. This needs to be passed to the `docker run` command or your docker compose file.